### PR TITLE
chore: flip graphics and text order for 2 sections in index.js

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -33,14 +33,14 @@ class Index extends React.Component {
         </Block>
 
         <Block className="stripe bg-dots">
-          <Block.Container>
+          <Block.Container reversed>
             <Block.TextBox>
               <Block.Title>Less wrangling, more building.</Block.Title>
               <Block.Paragraph>The philosophy behind Backstage is simple: Don't expose your engineers to the full complexity of your infrastructure tooling. Engineers should be shipping code — not figuring out a whole new toolset every time they want to implement the basics.</Block.Paragraph>
             </Block.TextBox>
             <Block.Graphics style={{margin: '0 100px'}}>
               <Breakpoint
-                wide={<Block.Graphic x={-28} y={5} width={260} src={`${baseUrl}img/logos-background.svg`}/>}
+                wide={<Block.Graphic x={-30} y={5} width={158} src={`${baseUrl}img/logos-background.svg`}/>}
                 narrow={<div className='logos-mobile-background'/>}
               />
               <Block.Graphic x={20} y={10} width={60} src={`${baseUrl}img/logos.svg`}/>
@@ -59,7 +59,7 @@ class Index extends React.Component {
         </ActionBlock>
 
         <Block className="stripe bg-black">
-          <Block.Container reversed>
+          <Block.Container>
             <Block.TextBox>
               <Block.Title>As simple as writing a plugin.</Block.Title>
               <Block.Paragraph>Backstage makes unifying all of your infrastructure tooling, services, and documentation as simple as writing a plugin. With all your developer tools
@@ -67,8 +67,8 @@ in one place, your engineers will always know where to find the right tool for t
             </Block.TextBox>
             <Block.Graphics>
               <Breakpoint
-                wide={<Block.Graphic x={-20} y={-5} width={140} src={`${baseUrl}img/plugin.svg`}/>}
-                narrow={<Block.Graphic x={-23.5} y={-5} width={135} src={`${baseUrl}img/plugin-mobile.svg`}/>}
+                wide={<Block.Graphic x={-5} y={-5} width={132} src={`${baseUrl}img/plugin.svg`}/>}
+                narrow={<Block.Graphic x={-23.5} y={-5} width={132} src={`${baseUrl}img/plugin-mobile.svg`}/>}
               />
             </Block.Graphics>
           </Block.Container>

--- a/website/static/img/logos-background.svg
+++ b/website/static/img/logos-background.svg
@@ -1,19 +1,19 @@
-<svg width="1745" height="1325" viewBox="0 0 1745 1325" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="211" width="635" height="428" fill="url(#paint0_linear)" fill-opacity="0.2"/>
-<path opacity="0.7" d="M846 428L1040.13 623L0 675.02L211 428H846Z" fill="url(#paint1_linear)" fill-opacity="0.4"/>
-<path opacity="0.4" d="M846 428L1739 1325L1739 895.902L846 0L846 428Z" fill="url(#paint2_linear)"/>
+<svg width="1045" height="732" viewBox="0 0 1045 732" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M216.339 0.0976562H850.906L851 428H216L216.339 0.0976562Z" fill="url(#paint0_linear)" fill-opacity="0.2"/>
+<path opacity="0.7" d="M851 428L1044.08 623.039L5 675L216 428H851Z" fill="url(#paint1_linear)" fill-opacity="0.4"/>
+<path opacity="0.4" d="M216 428L5 675L0.875333 213.864L215.84 0L216 428Z" fill="url(#paint2_linear)"/>
 <defs>
-<linearGradient id="paint0_linear" x1="575" y1="346.5" x2="568.978" y2="0.000383965" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint0_linear" x1="502.284" y1="611.511" x2="519.85" y2="14.2722" gradientUnits="userSpaceOnUse">
 <stop stop-color="#9BF0E1"/>
 <stop offset="1" stop-color="#9BF0E1" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint1_linear" x1="519.565" y1="428" x2="519.565" y2="675.02" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint1_linear" x1="524.516" y1="428.168" x2="524.516" y2="675.188" gradientUnits="userSpaceOnUse">
 <stop stop-color="#9BF0E1"/>
 <stop offset="1" stop-color="#9BF0E1" stop-opacity="0"/>
 </linearGradient>
-<linearGradient id="paint2_linear" x1="581.5" y1="728.5" x2="1044.5" y2="132" gradientUnits="userSpaceOnUse">
+<linearGradient id="paint2_linear" x1="345.025" y1="454.402" x2="92.5255" y2="206.902" gradientUnits="userSpaceOnUse">
 <stop stop-color="#9BF0E1"/>
-<stop offset="0.963542" stop-color="#9BF0E1" stop-opacity="0.01"/>
+<stop offset="1" stop-color="#9BF0E1" stop-opacity="0"/>
 </linearGradient>
 </defs>
 </svg>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Updated logos-background.svg
- Added `reversed` prop to flip graphics and text order for 2 sections. Also tweaked graphics width and x-y positions so they look better.

Resolves #142

![Screen Shot 2020-04-21 at 9 36 45 AM](https://user-images.githubusercontent.com/1919336/79890361-3d0f8280-83b4-11ea-8b41-5795d2a5da57.png)
![Screen Shot 2020-04-21 at 9 36 59 AM](https://user-images.githubusercontent.com/1919336/79890375-400a7300-83b4-11ea-9694-208db7696aa9.png)


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply or add more if needed -->

- [x] Website is working locally `yarn start`
- [x] Screenshots attached (for UI changes)
- [x] Prettier run on changed files
