### PR TITLE
Change the background color of the Blog page (#159)

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -49,7 +49,7 @@ const siteConfig = {
   /* Colors for website */
   colors: {
     primaryColor: "#36BAA2",
-    secondaryColor: "#191414",
+    secondaryColor: "#121212",
     textColor: "#FFFFFF",
     navigatorTitleTextColor: "#9e9e9e",
     navigatorItemTextColor: "#616161"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hi, I fixed #159 .
Specifically, I changed the colors.secondaryColor in siteConfig.js to #12121212.

The screenshots before and after the change are attached below.

Before
<img width="573" alt="スクリーンショット 2020-04-30 21 59 55" src="https://user-images.githubusercontent.com/38906043/80713821-09102c00-8b2f-11ea-984d-6c1c2f08eb4e.png">

After
<img width="554" alt="スクリーンショット 2020-04-30 22 00 06" src="https://user-images.githubusercontent.com/38906043/80713848-13cac100-8b2f-11ea-81cd-1beef2907d41.png">

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply or add more if needed -->

- [x] Website is working locally `yarn start`
- [x] Screenshots attached (for UI changes)
- [x] Prettier run on changed files
