### PR TITLE
Added Block.MediaFrame

### DIFF
--- a/website/core/Components.js
+++ b/website/core/Components.js
@@ -35,6 +35,7 @@ Block.LinkButton = simpleComponent('a', 'Block__LinkButton')
 Block.QuoteContainer = simpleComponent('div', 'Block__QuoteContainer')
 Block.Quote = simpleComponent('p', 'Block__Quote')
 Block.Divider = simpleComponent('p', 'Block__Divider', ['quote'])
+Block.MediaFrame = simpleComponent('div', 'Block__MediaFrame')
 Block.Graphics = ({children}) => (
     <div className='Block__GraphicsContainer'>
         <div className='Block__Graphics' children={children}/>

--- a/website/pages/en/demos.js
+++ b/website/pages/en/demos.js
@@ -36,9 +36,9 @@ const Background = (props) => {
             <Block.Paragraph>Backstage is an open source platform for building developer portals. We’ve been using our homegrown version at Spotify for years — so it’s already packed with features. (We have over 120 internal plugins, built by 60 different teams.) In this live demo recording, Stefan Ålund, product manager for Backstage, tells the origin story of Backstage and gives you a tour of how we use it here at Spotify.</Block.Paragraph>
             <Block.LinkButton href={"https://www.youtube.com/watch?v=1XtJ5FAOjPk"}>Watch now</Block.LinkButton>
           </Block.TextBox>
-          <Block.TextBox>
+          <Block.MediaFrame> 
             <iframe width="800" height="500" src="https://www.youtube.com/embed/1XtJ5FAOjPk" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
-          </Block.TextBox>
+          </Block.MediaFrame>
         </Block.Container>
       </Block>
 
@@ -50,9 +50,9 @@ const Background = (props) => {
 
             <Block.LinkButton href={"https://www.youtube.com/watch?v=K3xz6VAbgH8&list=PLf1KFlSkDLIBtMGwRDfaVlKMqTMrjD2yO&index=6"}>Watch now</Block.LinkButton>
           </Block.TextBox>
-          <Block.TextBox>
+          <Block.MediaFrame>
             <iframe width="800" height="500" src="https://www.youtube.com/embed/K3xz6VAbgH8" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
-          </Block.TextBox>
+          </Block.MediaFrame>
         </Block.Container>
       </Block>
 
@@ -64,9 +64,9 @@ const Background = (props) => {
 
             <Block.LinkButton href={"https://www.youtube.com/watch?v=U1iwe3L5pzc"}>Watch now</Block.LinkButton>
           </Block.TextBox>
-          <Block.TextBox>
+          <Block.MediaFrame>
             <iframe width="800" height="500" src="https://www.youtube.com/embed/U1iwe3L5pzc" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
-          </Block.TextBox>
+          </Block.MediaFrame>
         </Block.Container>
       </Block>
 
@@ -79,9 +79,9 @@ const Background = (props) => {
             </Block.Paragraph>
             <Block.LinkButton href={"https://www.youtube.com/watch?v=vcDL9tOv7Eo"}>Watch now</Block.LinkButton>
           </Block.TextBox>
-          <Block.TextBox>
+          <Block.MediaFrame>
             <iframe width="800" height="500" src="https://www.youtube.com/embed/vcDL9tOv7Eo" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
-          </Block.TextBox>
+          </Block.MediaFrame>
         </Block.Container>
       </Block>
 
@@ -92,9 +92,9 @@ const Background = (props) => {
           <Block.Paragraph>We manage a lot of data pipelines (also known as workflows) here at Spotify. So, of course, we made a great workflows plugin for our version of Backstage. All our workflow tools — including a scheduler, log inspector, data lineage graph, and configurable alerts — are integrated into one simple interface.</Block.Paragraph>
           <Block.LinkButton href={"https://www.youtube.com/watch?v=rH46MLNZIPM "}>Watch now</Block.LinkButton>
         </Block.TextBox>
-        <Block.TextBox>
+        <Block.MediaFrame>
           <iframe width="800" height="500" src="https://www.youtube.com/embed/rH46MLNZIPM" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen></iframe>
-        </Block.TextBox>
+        </Block.MediaFrame>
       </Block.Container>
       </Block>
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -411,7 +411,28 @@ code {
   flex: 1 1 0;
 }
 
+.Block__MediaFrame{
+  width: 55%;
+  height: 500px;
+  padding: 20px 0;
+  flex: 0 0 auto;
+  align-self: flex-start;
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+}
+
+.Block__MediaFrame iframe{
+  width: 100% !important;
+  height: 100% !important;
+}
+
 @media only screen and (max-width: 1400px) {
+  .Block__MediaFrame{
+    width: 100%;
+  }
+
   .Block__TextBox {
     align-self: center;
     height: auto;
@@ -435,7 +456,14 @@ code {
   line-height: 56px;
   word-break: break-word;
 }
-
+@media only screen and (max-width: 485px) {
+  .Block__Title{
+    text-align: start;
+    word-break: keep-all;
+    font-size: 43px;
+    line-height: 45px;
+  }
+}
 .Block__Paragraph {
   color: #fff;
   font-style: normal;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
### Changes for mobile UX:
The following changes pertain to #191 
- Added a new component to house iframes for reactive styling.
- Adjusted Block__Title for mobile platforms to not break mid word. 

Note: The adjustments to Block__Title will only affect screen widths under 485px

### Old iframe handling 
![Screen Shot 2020-07-25 at 2 24 00 PM](https://user-images.githubusercontent.com/20445056/88463791-752ad380-ce83-11ea-9860-ff6fb7db35ad.jpg)

### New component housing iframe
![Screen Shot 2020-07-25 at 2 24 09 PM](https://user-images.githubusercontent.com/20445056/88463800-84118600-ce83-11ea-9ff0-c0bbaf4828b5.jpg)

### Old Title format
![Screen Shot 2020-07-25 at 2 24 39 PM](https://user-images.githubusercontent.com/20445056/88463809-955a9280-ce83-11ea-89bb-6067be8786d5.jpg)

### New Title format 
![Screen Shot 2020-07-25 at 2 24 45 PM](https://user-images.githubusercontent.com/20445056/88463815-a0152780-ce83-11ea-9f7a-263387dca634.jpg)


#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply or add more if needed -->

- [x] Website is working locally `yarn start`
- [x] Screenshots attached (for UI changes)
- [x] Prettier run on changed files
